### PR TITLE
Support loading multiple dependencies in LoadSnapshot fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ Icons:
 
 ## [0.9.0] - 2025-10-23
 - 🆕 Added class method for handling objects in LoadSnapshot fixture
+- 🆕 Added support for multiple snapshots loaded in the same LoadSnapshot fixture, if multiple functions are added to the depends.
 - 🐞 Fix snappylapy logo not showing correctly in documentation
+- 🐞 Fix issue when snapshots is loaded from another folder and the path is added to the depending file name
 
 ## [0.8.0] - 2025-10-18
 - 🆕 Used integration with toolit to make snappylapy commands available for AI coding assistants

--- a/snappylapy/_plugin.py
+++ b/snappylapy/_plugin.py
@@ -94,6 +94,7 @@ def snappylapy_settings(request: pytest.FixtureRequest) -> Settings:
                 test_filename=_extract_module_name(depend.__module__),
                 test_function=depend.__name__,
                 snapshots_base_dir=path_output_dir or DEFAULT_SNAPSHOT_BASE_DIR,
+                custom_name=settings.custom_name,
             )
             settings.depending_tests.append(dependency_setting)
 

--- a/snappylapy/_plugin.py
+++ b/snappylapy/_plugin.py
@@ -18,6 +18,15 @@ from snappylapy.session import SnapshotSession
 from typing import Any
 
 
+def _extract_module_name(module_path: str) -> str:
+    """
+    Extract the module name from a dotted module path, returning only the last component.
+
+    This is used to strip package paths and keep only the module's filename for snapshot tracking.
+    """
+    return module_path.split(".", maxsplit=1)[-1]
+
+
 def _get_kwargs_from_depend_function(
     depends_function: Callable,
     marker_name: str,
@@ -82,12 +91,10 @@ def snappylapy_settings(request: pytest.FixtureRequest) -> Settings:
             if input_dir_from_depends:
                 path_output_dir = pathlib.Path(input_dir_from_depends)
             dependency_setting = DependingSettings(
-                test_filename=depend.__module__,
+                test_filename=_extract_module_name(depend.__module__),
                 test_function=depend.__name__,
                 snapshots_base_dir=path_output_dir or DEFAULT_SNAPSHOT_BASE_DIR,
             )
-            # Extract only the module name (without package path) for test_filename.
-            dependency_setting.test_filename = dependency_setting.test_filename.split(".")[-1]
             settings.depending_tests.append(dependency_setting)
 
     return settings

--- a/snappylapy/_plugin.py
+++ b/snappylapy/_plugin.py
@@ -82,10 +82,12 @@ def snappylapy_settings(request: pytest.FixtureRequest) -> Settings:
             if input_dir_from_depends:
                 path_output_dir = pathlib.Path(input_dir_from_depends)
             dependency_setting = DependingSettings(
-                test_filename=depend.__module__, test_function=depend.__name__, snapshots_base_dir=path_output_dir or DEFAULT_SNAPSHOT_BASE_DIR
+                test_filename=depend.__module__,
+                test_function=depend.__name__,
+                snapshots_base_dir=path_output_dir or DEFAULT_SNAPSHOT_BASE_DIR,
             )
-            if isinstance(dependency_setting.test_filename, str):
-                dependency_setting.test_filename = dependency_setting.test_filename.split(".")[-1]
+            # Extract only the module name (without package path) for test_filename.
+            dependency_setting.test_filename = dependency_setting.test_filename.split(".")[-1]
             settings.depending_tests.append(dependency_setting)
 
     return settings

--- a/snappylapy/fixtures.py
+++ b/snappylapy/fixtures.py
@@ -375,16 +375,17 @@ class LoadSnapshot:
     def __init__(self, settings: Settings) -> None:
         """Do not initialize the LoadSnapshot class directly, should be used through the `load_snapshot` fixture in pytest."""  # noqa: E501
         self.settings = settings
+        self._dependency_loaded_counter = 0
 
     def _read_snapshot(self) -> bytes:
         """Read the snapshot file."""
-        if not self.settings.depending_tests[0].snapshots_base_dir:
+        if not self.settings.depending_tests[self._dependency_loaded_counter].snapshots_base_dir:
             msg = "Depending snapshots base directory is not set."
             raise ValueError(msg)
         return (
-            self.settings.depending_tests[0].snapshots_base_dir
+            self.settings.depending_tests[self._dependency_loaded_counter].snapshots_base_dir
             / DIRECTORY_NAMES.snapshot_dir_name
-            / self.settings.depending_tests[0].filename
+            / self.settings.depending_tests[self._dependency_loaded_counter].filename
         ).read_bytes()
 
     def dict(self) -> dict[Any, Any]:
@@ -415,8 +416,10 @@ class LoadSnapshot:
             assert data["bananas"] == 5
         ```
         """
-        self.settings.depending_tests[0].filename_extension = "dict.json"
-        return JsonPickleSerializer[dict]().deserialize(self._read_snapshot())
+        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "dict.json"
+        deserialized_data = JsonPickleSerializer[dict]().deserialize(self._read_snapshot())
+        self._dependency_loaded_counter += 1
+        return deserialized_data
 
     def list(self) -> list[Any]:
         """
@@ -451,8 +454,10 @@ class LoadSnapshot:
             expect(result).to_match_snapshot()
         ```
         """
-        self.settings.depending_tests[0].filename_extension = "list.json"
-        return JsonPickleSerializer[list[Any]]().deserialize(self._read_snapshot())
+        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "list.json"
+        deserialized_data = JsonPickleSerializer[list[Any]]().deserialize(self._read_snapshot())
+        self._dependency_loaded_counter += 1
+        return deserialized_data
 
     def string(self) -> str:
         """
@@ -478,8 +483,10 @@ class LoadSnapshot:
             assert data == "Hello, pytest!"
         ```
         """
-        self.settings.depending_tests[0].filename_extension = "string.txt"
-        return StringSerializer().deserialize(self._read_snapshot())
+        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "string.txt"
+        deserialized_data = StringSerializer().deserialize(self._read_snapshot())
+        self._dependency_loaded_counter += 1
+        return deserialized_data
 
     def bytes(self) -> bytes:
         r"""
@@ -505,8 +512,10 @@ class LoadSnapshot:
             assert data == b"\x01\x02\x03"
         ```
         """
-        self.settings.depending_tests[0].filename_extension = "bytes.txt"
-        return BytesSerializer().deserialize(self._read_snapshot())
+        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "bytes.txt"
+        deserialized_data = BytesSerializer().deserialize(self._read_snapshot())
+        self._dependency_loaded_counter += 1
+        return deserialized_data
 
     def dataframe(self) -> DataframeExpect.DataFrame:
         """
@@ -533,8 +542,10 @@ class LoadSnapshot:
             assert df["numbers"].sum() == 6
         ```
         """
-        self.settings.depending_tests[0].filename_extension = "dataframe.csv"
-        return PandasCsvSerializer().deserialize(self._read_snapshot())
+        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "dataframe.csv"
+        deserialized_data = PandasCsvSerializer().deserialize(self._read_snapshot())
+        self._dependency_loaded_counter += 1
+        return deserialized_data
 
     def object(self) -> object:
         """
@@ -565,5 +576,7 @@ class LoadSnapshot:
             assert obj.value == 42
         ```
         """
-        self.settings.depending_tests[0].filename_extension = "object.json"
-        return JsonPickleSerializer[object]().deserialize(self._read_snapshot())
+        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "object.json"
+        deserialized_data = JsonPickleSerializer[object]().deserialize(self._read_snapshot())
+        self._dependency_loaded_counter += 1
+        return deserialized_data

--- a/snappylapy/fixtures.py
+++ b/snappylapy/fixtures.py
@@ -24,11 +24,14 @@ from .serialization import (
     BytesSerializer,
     JsonPickleSerializer,
     PandasCsvSerializer,
+    Serializer,
     StringSerializer,
 )
 from snappylapy.constants import DIRECTORY_NAMES
 from snappylapy.session import SnapshotSession
-from typing import Any, Protocol, overload
+from typing import Any, Protocol, TypeVar, overload
+
+T = TypeVar("T")
 
 
 class _CallableExpectation(Protocol):
@@ -375,18 +378,32 @@ class LoadSnapshot:
     def __init__(self, settings: Settings) -> None:
         """Do not initialize the LoadSnapshot class directly, should be used through the `load_snapshot` fixture in pytest."""  # noqa: E501
         self.settings = settings
-        self._dependency_loaded_counter = 0
+        self._current_dependency_index = 0
 
     def _read_snapshot(self) -> bytes:
         """Read the snapshot file."""
-        if not self.settings.depending_tests[self._dependency_loaded_counter].snapshots_base_dir:
+        if self._current_dependency_index >= len(self.settings.depending_tests):
+            msg = (
+                f"Attempted to load more dependencies ({self._current_dependency_index + 1}) "
+                f"than available ({len(self.settings.depending_tests)}). "
+                "Check your test's dependency configuration."
+            )
+            raise IndexError(msg)
+        if not self.settings.depending_tests[self._current_dependency_index].snapshots_base_dir:
             msg = "Depending snapshots base directory is not set."
             raise ValueError(msg)
         return (
-            self.settings.depending_tests[self._dependency_loaded_counter].snapshots_base_dir
+            self.settings.depending_tests[self._current_dependency_index].snapshots_base_dir
             / DIRECTORY_NAMES.snapshot_dir_name
-            / self.settings.depending_tests[self._dependency_loaded_counter].filename
+            / self.settings.depending_tests[self._current_dependency_index].filename
         ).read_bytes()
+
+    def _load_and_deserialize(self, filename_extension: str, deserializer: Serializer[T]) -> T:
+        """Set filename extension, read, deserialize, and increment dependency index."""
+        self.settings.depending_tests[self._current_dependency_index].filename_extension = filename_extension
+        deserialized_data = deserializer.deserialize(self._read_snapshot())
+        self._current_dependency_index += 1
+        return deserialized_data
 
     def dict(self) -> dict[Any, Any]:
         """
@@ -416,10 +433,10 @@ class LoadSnapshot:
             assert data["bananas"] == 5
         ```
         """
-        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "dict.json"
-        deserialized_data = JsonPickleSerializer[dict]().deserialize(self._read_snapshot())
-        self._dependency_loaded_counter += 1
-        return deserialized_data
+        return self._load_and_deserialize(
+            "dict.json",
+            JsonPickleSerializer[dict](),
+        )
 
     def list(self) -> list[Any]:
         """
@@ -454,10 +471,10 @@ class LoadSnapshot:
             expect(result).to_match_snapshot()
         ```
         """
-        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "list.json"
-        deserialized_data = JsonPickleSerializer[list[Any]]().deserialize(self._read_snapshot())
-        self._dependency_loaded_counter += 1
-        return deserialized_data
+        return self._load_and_deserialize(
+            "list.json",
+            JsonPickleSerializer[list[Any]](),
+        )
 
     def string(self) -> str:
         """
@@ -483,10 +500,10 @@ class LoadSnapshot:
             assert data == "Hello, pytest!"
         ```
         """
-        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "string.txt"
-        deserialized_data = StringSerializer().deserialize(self._read_snapshot())
-        self._dependency_loaded_counter += 1
-        return deserialized_data
+        return self._load_and_deserialize(
+            "string.txt",
+            StringSerializer(),
+        )
 
     def bytes(self) -> bytes:
         r"""
@@ -512,10 +529,10 @@ class LoadSnapshot:
             assert data == b"\x01\x02\x03"
         ```
         """
-        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "bytes.txt"
-        deserialized_data = BytesSerializer().deserialize(self._read_snapshot())
-        self._dependency_loaded_counter += 1
-        return deserialized_data
+        return self._load_and_deserialize(
+            "bytes.txt",
+            BytesSerializer(),
+        )
 
     def dataframe(self) -> DataframeExpect.DataFrame:
         """
@@ -542,10 +559,10 @@ class LoadSnapshot:
             assert df["numbers"].sum() == 6
         ```
         """
-        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "dataframe.csv"
-        deserialized_data = PandasCsvSerializer().deserialize(self._read_snapshot())
-        self._dependency_loaded_counter += 1
-        return deserialized_data
+        return self._load_and_deserialize(
+            "dataframe.csv",
+            PandasCsvSerializer(),
+        )
 
     def object(self) -> object:
         """
@@ -576,7 +593,7 @@ class LoadSnapshot:
             assert obj.value == 42
         ```
         """
-        self.settings.depending_tests[self._dependency_loaded_counter].filename_extension = "object.json"
-        deserialized_data = JsonPickleSerializer[object]().deserialize(self._read_snapshot())
-        self._dependency_loaded_counter += 1
-        return deserialized_data
+        return self._load_and_deserialize(
+            "object.json",
+            JsonPickleSerializer[object](),
+        )

--- a/snappylapy/fixtures.py
+++ b/snappylapy/fixtures.py
@@ -378,13 +378,13 @@ class LoadSnapshot:
 
     def _read_snapshot(self) -> bytes:
         """Read the snapshot file."""
-        if not self.settings.depending_snapshots_base_dir:
+        if not self.settings.depending_tests[0].snapshots_base_dir:
             msg = "Depending snapshots base directory is not set."
             raise ValueError(msg)
         return (
-            self.settings.depending_snapshots_base_dir
+            self.settings.depending_tests[0].snapshots_base_dir
             / DIRECTORY_NAMES.snapshot_dir_name
-            / self.settings.depending_filename
+            / self.settings.depending_tests[0].filename
         ).read_bytes()
 
     def dict(self) -> dict[Any, Any]:
@@ -415,7 +415,7 @@ class LoadSnapshot:
             assert data["bananas"] == 5
         ```
         """
-        self.settings.depending_filename_extension = "dict.json"
+        self.settings.depending_tests[0].filename_extension = "dict.json"
         return JsonPickleSerializer[dict]().deserialize(self._read_snapshot())
 
     def list(self) -> list[Any]:
@@ -451,7 +451,7 @@ class LoadSnapshot:
             expect(result).to_match_snapshot()
         ```
         """
-        self.settings.depending_filename_extension = "list.json"
+        self.settings.depending_tests[0].filename_extension = "list.json"
         return JsonPickleSerializer[list[Any]]().deserialize(self._read_snapshot())
 
     def string(self) -> str:
@@ -478,7 +478,7 @@ class LoadSnapshot:
             assert data == "Hello, pytest!"
         ```
         """
-        self.settings.depending_filename_extension = "string.txt"
+        self.settings.depending_tests[0].filename_extension = "string.txt"
         return StringSerializer().deserialize(self._read_snapshot())
 
     def bytes(self) -> bytes:
@@ -505,7 +505,7 @@ class LoadSnapshot:
             assert data == b"\x01\x02\x03"
         ```
         """
-        self.settings.depending_filename_extension = "bytes.txt"
+        self.settings.depending_tests[0].filename_extension = "bytes.txt"
         return BytesSerializer().deserialize(self._read_snapshot())
 
     def dataframe(self) -> DataframeExpect.DataFrame:
@@ -533,7 +533,7 @@ class LoadSnapshot:
             assert df["numbers"].sum() == 6
         ```
         """
-        self.settings.depending_filename_extension = "dataframe.csv"
+        self.settings.depending_tests[0].filename_extension = "dataframe.csv"
         return PandasCsvSerializer().deserialize(self._read_snapshot())
 
     def object(self) -> object:
@@ -565,5 +565,5 @@ class LoadSnapshot:
             assert obj.value == 42
         ```
         """
-        self.settings.depending_filename_extension = "object.json"
+        self.settings.depending_tests[0].filename_extension = "object.json"
         return JsonPickleSerializer[object]().deserialize(self._read_snapshot())

--- a/snappylapy/models.py
+++ b/snappylapy/models.py
@@ -61,6 +61,11 @@ class Settings:
 
     # Configurations for depending
     depending_tests: list[DependingSettings] = field(default_factory=list)
+    """
+    Depending tests are used for loading snapshots from other tests.
+
+    Information about each test the users have specified in a test decorator will be stored here.
+    """
 
     @property
     def snapshot_dir(self) -> pathlib.Path:

--- a/snappylapy/models.py
+++ b/snappylapy/models.py
@@ -3,8 +3,38 @@
 from __future__ import annotations
 
 import pathlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from snappylapy.constants import DIRECTORY_NAMES
+
+
+@dataclass
+class DependingSettings:
+    """Settings for depending on other snapshots. Used for loading snapshots."""
+
+    test_filename: str
+    """Filename of the test module where the depending test are defined."""
+
+    test_function: str
+    """Name of the depending test function."""
+
+    snapshots_base_dir: pathlib.Path
+    """Input base directory for loading snapshots."""
+
+    filename_extension: str | None = None
+    """Extension of the depending snapshot file."""
+
+    custom_name: str | None = None
+    """Custom name for the depending snapshot file."""
+
+    @property
+    def filename(self) -> str:
+        """Get the depending snapshot filename."""
+        if not self.test_filename or not self.test_function or not self.filename_extension:
+            msg = "Missing depending test filename, function or extension."
+            raise ValueError(msg)
+        if self.custom_name is not None:
+            return f"[{self.test_filename}][{self.test_function}][{self.custom_name}].{self.filename_extension}"  # noqa: E501
+        return f"[{self.test_filename}][{self.test_function}].{self.filename_extension}"
 
 
 @dataclass
@@ -30,17 +60,7 @@ class Settings:
     """Extension for the output of snapshot file."""
 
     # Configurations for depending
-    depending_test_filename: str | None = None
-    """Filename of the test module where the depending test are defined. Used for loading."""
-
-    depending_test_function: str | None = None
-    """Name of the depending test function. Used for loading."""
-
-    depending_filename_extension: str | None = None
-    """Extension of the depending snapshot file. Used for loading."""
-
-    depending_snapshots_base_dir: pathlib.Path | None = None
-    """Input base directory for loading snapshots."""
+    depending_tests: list[DependingSettings] = field(default_factory=list)
 
     @property
     def snapshot_dir(self) -> pathlib.Path:
@@ -58,17 +78,3 @@ class Settings:
         if self.custom_name is not None:
             return f"[{self.test_filename}][{self.test_function}][{self.custom_name}].{self.filename_extension}"
         return f"[{self.test_filename}][{self.test_function}].{self.filename_extension}"
-
-    @property
-    def depending_filename(self) -> str:
-        """Get the depending snapshot filename."""
-        if (
-            not self.depending_test_filename
-            or not self.depending_test_function
-            or not self.depending_filename_extension
-        ):
-            msg = "Missing depending test filename, function or extension."
-            raise ValueError(msg)
-        if self.custom_name is not None:
-            return f"[{self.depending_test_filename}][{self.depending_test_function}][{self.custom_name}].{self.depending_filename_extension}"  # noqa: E501
-        return f"[{self.depending_test_filename}][{self.depending_test_function}].{self.depending_filename_extension}"

--- a/snappylapy/models.py
+++ b/snappylapy/models.py
@@ -29,11 +29,11 @@ class DependingSettings:
     @property
     def filename(self) -> str:
         """Get the depending snapshot filename."""
-        if not self.test_filename or not self.test_function or not self.filename_extension:
-            msg = "Missing depending test filename, function or extension."
+        if not self.filename_extension:
+            msg = "Missing depending snapshot filename extension."
             raise ValueError(msg)
         if self.custom_name is not None:
-            return f"[{self.test_filename}][{self.test_function}][{self.custom_name}].{self.filename_extension}"  # noqa: E501
+            return f"[{self.test_filename}][{self.test_function}][{self.custom_name}].{self.filename_extension}"
         return f"[{self.test_filename}][{self.test_function}].{self.filename_extension}"
 
 


### PR DESCRIPTION
Enhance the LoadSnapshot fixture to accommodate multiple dependencies, allowing for more flexible snapshot loading. Refactor code for clarity and fix linting issues. Update the changelog to reflect these changes.